### PR TITLE
Update setup and runscript to use bc for floating point lat/lon arithmetic

### DIFF
--- a/run_ch4_inversion.sh
+++ b/run_ch4_inversion.sh
@@ -197,10 +197,11 @@ if "$DoPosterior"; then
     printf "=== DONE -- setup_GCdatadir.py ===\n"
 
     # Sample GEOS-Chem atmosphere with TROPOMI
-    LonMinInvDomain=$(( LonMin-BufferDeg ))
-    LonMaxInvDomain=$(( LonMax+BufferDeg ))
-    LatMinInvDomain=$(( LatMin-BufferDeg ))
-    LatMaxInvDomain=$(( LatMax+BufferDeg ))
+    # Here we use bc to do floating point arithmetic
+    LonMinInvDomain=`echo "$LonMin-$BufferDeg" | bc`
+    LonMaxInvDomain=`echo "$LonMax+$BufferDeg" | bc`
+    LatMinInvDomain=`echo "$LatMin-$BufferDeg" | bc`
+    LatMaxInvDomain=`echo "$LatMax+$BufferDeg" | bc`
     StateVectorFilePath="${MyPath}/${RunName}/StateVector.nc"
     if ! "$CreateStateVectorFile"; then
         LonMinInvDomain=${LonMinCustomStateVector}

--- a/setup_ch4_inversion.sh
+++ b/setup_ch4_inversion.sh
@@ -283,10 +283,11 @@ if "$SetupTemplateRundir"; then
     cd $RunTemplate
 
     # Define inversion domain lat/lon bounds
-    LonMinInvDomain=$(( LonMin-BufferDeg ))
-    LonMaxInvDomain=$(( LonMax+BufferDeg ))
-    LatMinInvDomain=$(( LatMin-BufferDeg ))
-    LatMaxInvDomain=$(( LatMax+BufferDeg ))
+    # Here we use bc to do floating point arithmetic
+    LonMinInvDomain=`echo "$LonMin-$BufferDeg" | bc`
+    LonMaxInvDomain=`echo "$LonMax+$BufferDeg" | bc`
+    LatMinInvDomain=`echo "$LatMin-$BufferDeg" | bc`
+    LatMaxInvDomain=`echo "$LatMax+$BufferDeg" | bc`
     # If using custom state vector
     if ! "$CreateStateVectorFile"; then
         LonMinInvDomain=${LonMinCustomStateVector}


### PR DESCRIPTION
@djvaron I think these are the only places where lat/lon arithmetic is performed within shell scripts (let me know if there are others). I tested by running the setup script and using `bc` seems to work.